### PR TITLE
- GraveMind accepts MessageDict and assigns metadata internally

### DIFF
--- a/MVCApplication/Controller/AccountController.cs
+++ b/MVCApplication/Controller/AccountController.cs
@@ -2,6 +2,10 @@
 using MVCApplication.Data;
 using static MVCApplication.Helpers.V;
 using static MVCApplication.Helpers.MessageDictionary;
+using static MVCApplication.Helpers.UserRole;
+using Microsoft.Extensions.Options;
+using MVCApplication.Models.Seeding;
+using MVCApplication.Helpers;
 
 namespace MVCApplication.Controllers
 {
@@ -10,12 +14,14 @@ namespace MVCApplication.Controllers
     /// </summary>
     public class AccountController : BaseAppController<AccountController>
     {
+        private readonly AdminSettings _adminSettings;
         /// <summary>
         /// Initializes a new instance of the AccountController class with the provided database context,
         /// </summary>  
         /// <param name="db">Application database context</param>
-        public AccountController(AppDb db, ILogger<AccountController> logger) : base(db,logger)
+        public AccountController(AppDb db, ILogger<AccountController> logger, IOptions<AdminSettings> adminSettings) : base(db,logger)
         {
+            _adminSettings = adminSettings.Value;
         }
 
         /// <summary>
@@ -24,7 +30,7 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <param name="returnUrl">Optional return URL after successful registration</param>
         [HttpGet("/Account/Register")]
-        public Task<IActionResult> Register(string? returnUrl = null) => !IsAuth ? GraveMind(Account.Register, Store[MethodCode.Register].Table, Store[MethodCode.Register].Title, redirect: () => Redirect(returnUrl)) : Task.FromResult<IActionResult>(RedirectToAction("Index", "Home"));
+        public Task<IActionResult> Register(string? returnUrl = null) => !IsAuth ? GraveMind(Account.Register, MethodCode.Register, redirect: () => Redirect(returnUrl)) : Task.FromResult<IActionResult>(RedirectToAction("Index", "Home"));
 
         /// <summary>
         /// Handles user by validating input and saving the new user to the database. 
@@ -49,17 +55,17 @@ namespace MVCApplication.Controllers
             string.IsNullOrEmpty(password) ||
             string.IsNullOrEmpty(username) ||
             string.IsNullOrEmpty(fullname)
-            ? GraveMind(Account.Register, Store[MethodCode.RegisterBlocked].Table, Store[MethodCode.RegisterBlocked].Title,
+            ? GraveMind(Account.Register, MethodCode.RegisterBlocked,
                 populate: async m => { m.Error = Store[MethodCode.RegisterBlocked].ErrorMsg; await Task.CompletedTask; })
-            : GraveMind(Account.Register, Store[MethodCode.Register].Table, Store[MethodCode.Register].Title, 
-                save: async () => await _db.Register(password, email, username, fullname, !string.IsNullOrEmpty(adminPassword) && adminPassword.ToLower().Trim() == "test" ? "admin" : "user") != null, errorMsg: Store[MethodCode.Register].ErrorMsg, successMsg: Store[MethodCode.Register].SuccessMsg, redirect: () => RedirectToAction("Login"));
+            : GraveMind(Account.Register, MethodCode.Register, 
+                save: async () => await _db.Register(password, email, username, fullname, !string.IsNullOrEmpty(adminPassword) && adminPassword.Trim() == _adminSettings.SeedPassword ? admin.ToString() : user.ToString()) != null, redirect: () => RedirectToAction("Login"));
 
         /// <summary>
         /// Displays the login page or redirects if the user is already authenticated.
         /// </summary>
         /// <param name="returnUrl">Optional return URL after login</param>
         [HttpGet("/Account/Login")]
-        public Task<IActionResult> Login(string? returnUrl = null) => !IsAuth ? GraveMind(Account.Login, Store[MethodCode.Login].Table, Store[MethodCode.Login].Title, redirect: () => Redirect(returnUrl)) : Task.FromResult<IActionResult>(RedirectToAction("Index", "Home"));
+        public Task<IActionResult> Login(string? returnUrl = null) => !IsAuth ? GraveMind(Account.Login, MethodCode.Login, redirect: () => Redirect(returnUrl)) : Task.FromResult<IActionResult>(RedirectToAction("Index", "Home"));
 
         /// <summary>
         /// Handles user login by validating credentials and setting session data.
@@ -71,9 +77,9 @@ namespace MVCApplication.Controllers
         [HttpPost("/Account/Login")]
         public Task<IActionResult> Login(string password, string email, string? returnurl = null) =>
             string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password)
-                ? GraveMind(Account.Login, Store[MethodCode.Login].Table, Store[MethodCode.Login].Title,
+                ? GraveMind(Account.Login, MethodCode.Login,
                     populate: m => { m.Error = Store[MethodCode.LoginInvalid].ErrorMsg; return Task.CompletedTask; })
-                : GraveMind(Account.Login, Store[MethodCode.Login].Table, Store[MethodCode.Login].Title,
+                : GraveMind(Account.Login, MethodCode.Login,
                     save: async () =>
                     {
                         var user = await _db.Login(password, email);
@@ -81,16 +87,15 @@ namespace MVCApplication.Controllers
                         if (user == null)
                             return false;
 
-                        HttpContext.Session.SetString("user", user.Email ?? "");
-                        HttpContext.Session.SetString("role", user.Role ?? "");
+                        HttpContext.Session.SetString(SessionKeys.Type, user.Email ?? "");
+                        HttpContext.Session.SetString(SessionKeys.Role, user.Role ?? "");
                         
                         return true;
                     },
                     redirect: () =>
                         !string.IsNullOrEmpty(returnurl) && Url.IsLocalUrl(returnurl)
                             ? Redirect(returnurl)
-                            : RedirectToAction("Index", "Home"),
-                    errorMsg: Store[MethodCode.Login].ErrorMsg, successMsg: Store[MethodCode.Login].SuccessMsg);
+                            : RedirectToAction("Index", "Home"));
 
         /// <summary>
         /// Logs the user out by clearing the session and redirects to the login page.

--- a/MVCApplication/Controller/AdminController.cs
+++ b/MVCApplication/Controller/AdminController.cs
@@ -3,6 +3,7 @@ using MVCApplication.Data;
 using MVCApplication.Models;
 using static MVCApplication.Helpers.V;
 using static MVCApplication.Helpers.MessageDictionary;
+using static MVCApplication.Helpers.ActionEnums;
 
 namespace MVCApplication.Controllers
 {
@@ -23,22 +24,22 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <returns>Admin dashboard view</returns>
         [HttpGet("/Admin")]
-        public Task<IActionResult> Index() => GraveMind(Admin.Index, Store[MethodCode.AdminIndex].Table, Store[MethodCode.AdminIndex].Title, admin: true);
+        public Task<IActionResult> Index() => GraveMind(Admin.Index, MethodCode.AdminIndex, admin: true);
 
         /// <summary>
         /// Displays all announcements for admin management. Requires admin access.
         /// </summary>
         /// <returns>Announcements view</returns>
         [HttpGet("/Admin/Announcements")]
-        public Task<IActionResult> Announcements() => GraveMind(Admin.Announcements, Store[MethodCode.AdminAnnouncements].Table, Store[MethodCode.AdminAnnouncements].Title, admin: true);
+        public Task<IActionResult> Announcements() => GraveMind(Admin.Announcements, MethodCode.AdminAnnouncements, admin: true);
 
         /// <summary>
         /// Displays all users and populates the model with user data from the database. Requires admin access.
         /// </summary>
         /// <returns>Users view with data</returns>
         [HttpGet("/Admin/Users")]
-        public Task<IActionResult> Users() => GraveMind(Admin.Users, Store[MethodCode.AdminUsers].Table, Store[MethodCode.AdminUsers].Title, admin: true,
-            populate: async m => { var (users, _) = await _db.GetUser(null); m.Users = users ?? []; }, errorMsg: Store[MethodCode.AdminUsers].ErrorMsg, successMsg: Store[MethodCode.AdminUsers].SuccessMsg);
+        public Task<IActionResult> Users() => GraveMind(Admin.Users, MethodCode.AdminUsers, admin: true,
+            populate: async m => { var (users, _) = await _db.GetUser(null); m.Users = users ?? []; });
 
         /// <summary>
         /// Handles user management actions such as create, update, and delete.
@@ -49,36 +50,22 @@ namespace MVCApplication.Controllers
         /// <param name="action">Action to perform (create, update, delete)</param>
         /// <returns>Redirects on success or returns the view with errors</returns>
         [HttpPost("/Admin/Users")]
-        public Task<IActionResult> Users(List<int>? id, List<User> users, User? user, string action) => string.IsNullOrEmpty(action)
-            ? GraveMind(Admin.Users, Store[MethodCode.AdminUsersInvalid].Table, Store[MethodCode.AdminUsersInvalid].Title, admin: true,
-                populate: async m => { var (users, _) = await _db.GetUser(null); m.Users = users ?? []; },
-                errorMsg: Store[MethodCode.AdminUsersInvalid].ErrorMsg)
-            : action == "delete" && id != null
-                ? GraveMind(Admin.Users,
-                    Store[MethodCode.AdminUsersDelete].Table,
-                    Store[MethodCode.AdminUsersDelete].Title,
+        public Task<IActionResult> Users(List<int>? id, List<User>? users, User? user, AdminUserAction? action) => action == null
+            ? GraveMind(Admin.Users, MethodCode.AdminUsersInvalid, admin: true,
+                populate: async m => { var (users, _) = await _db.GetUser(null); m.Users = users ?? []; })
+            : action == AdminUserAction.Delete && id != null
+                ? GraveMind(Admin.Users, MethodCode.AdminUsersDelete,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminUsersDelete].ErrorMsg,
-                    successMsg: Store[MethodCode.AdminUsersDelete].SuccessMsg,
                     save: () => _db.DeleteUsers(id),
                     redirect: () => RedirectToAction("Users"))
-            : action == "update" && users != null
-                ? GraveMind(Admin.Users,
-                    Store[MethodCode.AdminUsersUpdate].Table,
-                    Store[MethodCode.AdminUsersUpdate].Title,
+            : action == AdminUserAction.Update && users != null
+                ? GraveMind(Admin.Users, MethodCode.AdminUsersUpdate,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminUsersUpdate].ErrorMsg, 
-                    successMsg: Store[MethodCode.AdminUsersUpdate].SuccessMsg,
                     save: async () => await _db.UpdateUser(users) > 0,
                     redirect: () => RedirectToAction("Users"))
-            : action == "create" && user != null
-                ? GraveMind(Admin.Users,
-                    Store[MethodCode.AdminUsersCreate].Table,
-                    Store[MethodCode.AdminUsersCreate].Title,
+            : action == AdminUserAction.Create && user != null
+                ? GraveMind(Admin.Users, MethodCode.AdminUsersCreate,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminUsersCreate].ErrorMsg,
-                    successMsg: Store[MethodCode.AdminUsersCreate].SuccessMsg,
-                    save: () => _db.SaveUser(user),
                     redirect: () => RedirectToAction("Users"))
             : Task.FromResult(NotFound() as IActionResult);
 
@@ -87,8 +74,8 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <returns>Events view with data</returns>
         [HttpGet("/Admin/Events")]
-        public Task<IActionResult> Events() => GraveMind(Admin.Events, Store[MethodCode.AdminEvents].Table, Store[MethodCode.AdminEvents].Title, admin: true,
-            populate: async m => { var (e, _) = await _db.GetEvent(null); m.Events = e ?? []; }, errorMsg: Store[MethodCode.AdminEvents].ErrorMsg, successMsg: Store[MethodCode.AdminEvents].SuccessMsg);
+        public Task<IActionResult> Events() => GraveMind(Admin.Events, MethodCode.AdminEvents, admin: true,
+            populate: async m => { var (e, _) = await _db.GetEvent(null); m.Events = e ?? []; });
 
         /// <summary>
         /// Handles event management actions such as create, update, and delete.
@@ -99,35 +86,25 @@ namespace MVCApplication.Controllers
         /// <param name="action">Action to perform (create, update, delete)</param>
         /// <returns>Redirects on success or returns the view with errors</returns>
         [HttpPost("/Admin/Events")]
-        public Task<IActionResult> Events(List<int>? id, List<Event> events, Event? singleEvent, string action) => string.IsNullOrEmpty(action)
-            ? GraveMind(Admin.Events, Store[MethodCode.AdminEventsInvalid].Table, Store[MethodCode.AdminEventsInvalid].Title, admin: true,
-                populate: async m => { var (Events, _) = await _db.GetEvent(null); m.Events = Events ?? []; },
-                errorMsg: Store[MethodCode.AdminEventsInvalid].ErrorMsg)
-            : action == "delete" && id != null
+        public Task<IActionResult> Events(List<int>? id, List<Event>? events, Event? singleEvent, AdminUserAction? action) => action == null
+            ? GraveMind(Admin.Events, MethodCode.AdminEventsInvalid, admin: true,
+                populate: async m => { var (Events, _) = await _db.GetEvent(null); m.Events = Events ?? []; })
+            : action == AdminUserAction.Delete && id != null
                 ? GraveMind(Admin.Events,
-                    Store[MethodCode.AdminEventsDelete].Table,
-                    Store[MethodCode.AdminEventsDelete].Title,
+                    MethodCode.AdminEventsDelete,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminEventsDelete].ErrorMsg,
-                    successMsg: Store[MethodCode.AdminEventsDelete].SuccessMsg,
                     save: () => _db.DeleteEvents(id),
                     redirect: () => RedirectToAction("Events"))
-            : action == "update" && events != null
+            : action == AdminUserAction.Update && events != null
                 ? GraveMind(Admin.Events,
-                    Store[MethodCode.AdminEventsUpdate].Table,
-                    Store[MethodCode.AdminEventsUpdate].Title,
+                    MethodCode.AdminEventsUpdate,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminEventsUpdate].ErrorMsg,
-                    successMsg: Store[MethodCode.AdminEventsUpdate].SuccessMsg,
                     save: async () => await _db.UpdateEvent(events) > 0,
                     redirect: () => RedirectToAction("Events"))
-            : action == "create" && singleEvent != null
+            : action == AdminUserAction.Create && singleEvent != null
                 ? GraveMind(Admin.Events,
-                    Store[MethodCode.AdminEventsCreate].Table,
-                    Store[MethodCode.AdminEventsCreate].Title,
+                    MethodCode.AdminEventsCreate,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminEventsCreate].ErrorMsg, 
-                    successMsg: Store[MethodCode.AdminEventsCreate].SuccessMsg,
                     save: () => _db.SaveEvent(singleEvent),
                     redirect: () => RedirectToAction("Events"))
             : Task.FromResult(NotFound() as IActionResult);
@@ -137,8 +114,8 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <returns>Feedback view with data</returns>
         [HttpGet("/Admin/FeedBack")]
-        public Task<IActionResult> Feedback() => GraveMind(Admin.Feedback, Store[MethodCode.AdminFeedback].Table, Store[MethodCode.AdminFeedback].Title, admin: true,
-            populate: async m => { var (f, _) = await _db.GetFeedback(null); m.Feedbacks = f ?? []; }, errorMsg: Store[MethodCode.AdminFeedback].ErrorMsg, successMsg: Store[MethodCode.AdminFeedback].SuccessMsg);
+        public Task<IActionResult> Feedback() => GraveMind(Admin.Feedback, MethodCode.AdminFeedback, admin: true,
+            populate: async m => { var (f, _) = await _db.GetFeedback(null); m.Feedbacks = f ?? []; });
 
         /// <summary>
         /// Handles feedback management actions such as create, update, and delete.
@@ -149,35 +126,25 @@ namespace MVCApplication.Controllers
         /// <param name="action">Action to perform (create, update, delete)</param>
         /// <returns>Redirects on success or returns the view with errors</returns>
         [HttpPost("/Admin/FeedBack")]
-        public Task<IActionResult> Feedback(List<int>? id, List<Feedback> feedbacks, Feedback? feedback, string action) => string.IsNullOrEmpty(action)
-            ? GraveMind(Admin.Feedback, Store[MethodCode.AdminFeedbackInvalid].Table, Store[MethodCode.AdminFeedbackInvalid].Title, admin: true,
-                populate: async m => { var (f, _) = await _db.GetFeedback(null); m.Feedbacks = f ?? []; },
-                errorMsg: Store[MethodCode.AdminFeedbackInvalid].ErrorMsg)
-            : action == "delete" && id != null
+        public Task<IActionResult> Feedback(List<int>? id, List<Feedback>? feedbacks, Feedback? feedback, AdminUserAction? action) => action == null
+            ? GraveMind(Admin.Feedback, MethodCode.AdminFeedbackInvalid, admin: true,
+                populate: async m => { var (f, _) = await _db.GetFeedback(null); m.Feedbacks = f ?? []; })
+            : action == AdminUserAction.Delete && id != null
                 ? GraveMind(Admin.Feedback,
-                    Store[MethodCode.AdminFeedbackDelete].Table,
-                    Store[MethodCode.AdminFeedbackDelete].Title,
+                    MethodCode.AdminFeedbackDelete,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminFeedbackDelete].ErrorMsg,
-                    successMsg: Store[MethodCode.AdminFeedbackDelete].SuccessMsg,
                     save: () => _db.DeleteFeedbacks(id),
                     redirect: () => RedirectToAction("Feedback"))
-            : action == "update" && feedbacks != null
+            : action == AdminUserAction.Update && feedbacks != null
                 ? GraveMind(Admin.Feedback,
-                    Store[MethodCode.AdminFeedbackUpdate].Table,
-                    Store[MethodCode.AdminFeedbackUpdate].Title,
+                    MethodCode.AdminFeedbackUpdate,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminFeedbackUpdate].ErrorMsg,
-                    successMsg: Store[MethodCode.AdminFeedbackUpdate].SuccessMsg,
                     save: async () => await _db.UpdateFeedback(feedbacks) > 0,
                     redirect: () => RedirectToAction("Feedback"))
-            : action == "create" && feedback != null
+            : action == AdminUserAction.Create && feedback != null
                 ? GraveMind(Admin.Feedback,
-                    Store[MethodCode.AdminFeedbackCreate].Table,
-                    Store[MethodCode.AdminFeedbackCreate].Title,
+                    MethodCode.AdminFeedbackCreate,
                     admin: true,
-                    errorMsg: Store[MethodCode.AdminFeedbackCreate].ErrorMsg,
-                    successMsg: Store[MethodCode.AdminFeedbackCreate].SuccessMsg,
                     save: () => _db.SaveFeedback(feedback),
                     redirect: () => RedirectToAction("Feedback"))
             : Task.FromResult(NotFound() as IActionResult);
@@ -191,10 +158,7 @@ namespace MVCApplication.Controllers
         [HttpGet("/Admin/Logs")]
         public Task<IActionResult> Logs() => GraveMind(
             Admin.Logs,
-            Store[MethodCode.AdminLogs].Table,
-            Store[MethodCode.AdminLogs].Title,
-            errorMsg: Store[MethodCode.AdminLogs].ErrorMsg,
-            successMsg: Store[MethodCode.AdminLogs].SuccessMsg,
+            MethodCode.AdminLogs,
             admin: true,
             populate: async m =>
             {

--- a/MVCApplication/Controller/BaseAppController.cs
+++ b/MVCApplication/Controller/BaseAppController.cs
@@ -1,9 +1,10 @@
 ﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using MVCApplication.Data;
-using MVCApplication.Helpers;
 using MVCApplication.Models;
-using System.Linq;
+using static MVCApplication.Helpers.UserRole;
+using static MVCApplication.Helpers.MessageDictionary;
+using MVCApplication.Helpers;
 
 namespace MVCApplication.Controllers
 {
@@ -36,7 +37,7 @@ namespace MVCApplication.Controllers
         {
             get
             {
-                return HttpContext.Session.GetString("user") != null;
+                return HttpContext.Session.GetString(SessionKeys.Type) != null;
             }
         }
 
@@ -47,7 +48,7 @@ namespace MVCApplication.Controllers
         {
             get
             {
-                return HttpContext.Session.GetString("role") == "admin";
+                return HttpContext.Session.GetString(SessionKeys.Role) == admin.ToString();
             }
         }
 
@@ -63,8 +64,8 @@ namespace MVCApplication.Controllers
         {
             return AndInTheDarknessBindThem.Build(
                 table,
-                HttpContext.Session.GetString("user"),
-                HttpContext.Session.GetString("role"),
+                HttpContext.Session.GetString(SessionKeys.Type),
+                HttpContext.Session.GetString(SessionKeys.Role),
                 title,
                 returnUrl
             );
@@ -103,46 +104,40 @@ namespace MVCApplication.Controllers
         /// We Trade One Villain for Another 
         /// </summary>
         /// <param name="view"> Page to be displayed (Required) </param>
-        /// <param name="table"> Table name set onto model for View </param>
-        /// <param name="title"> Title of page set onto model for Views </param>
+        /// <param name="controllerOp">Key of Dict containing value pair of UX parameters</param>
         /// <param name="auth"> If True, required authenticated user </param>
         /// <param name="admin"> If True, required authenticated admin </param>
         /// <param name="populate"> Optional delegate that populates the view model with data from db before rendering the view </param>
         /// <param name="check"> Optional delegate that validates model and returns false to trigger 404 </param>
         /// <param name="save"> Optional delegate that does POST operations </param>
         /// <param name="redirect"> Optional delegate that stores where to be redirected to after a POST </param>
-        /// <param name="successMsg"> Optional message for successfull POST </param>
-        /// <param name="errorMsg"> Optional message for a failed operation or validation </param>
         /// <returns> An IActionResult representing either a view, redirect, or error response </returns>
 
-        protected Task<IActionResult> GraveMind(string view, string table = "", string? title = null,
+        protected Task<IActionResult> GraveMind(string view, MethodCode controllerOp,
             bool auth = false, bool admin = false,
             Func<AndInTheDarknessBindThem, Task>? populate = null,
             Func<AndInTheDarknessBindThem, bool>? check = null,
             Func<Task<bool>>? save = null,
-            Func<IActionResult>? redirect = null,
-            string? successMsg = null, string? errorMsg = null)
+            Func<IActionResult>? redirect = null)
             => 
-            logWrapper(HttpContext.Request.Path.Value ?? view, e: errorMsg, s: successMsg, 
+            logWrapper(HttpContext.Request.Path.Value ?? view, e: Store[controllerOp].ErrorMsg, s: Store[controllerOp].SuccessMsg, 
                 async() =>           
                     // Gate 1 (Auth and Admin)
                     Guard(requireAdmin: admin, requireAuth: auth) is { } r 
-                    ? await new Func<Task<IActionResult>>(() =>
-                    {
-                        return Task.FromResult(r);
-                    })() : save != null
+                    ? r : save != null
                     // Gate 2 POST
                     ? await new Func<Task<IActionResult>>(async () =>
                     {
-                        var m = Build(table, title);
+                        var op = Store[controllerOp];
+                        var m = Build(op.Table, op.Title);
                         var s = await save();
 
                         if (!s)
                         {
-                            m.Error = errorMsg;
+                            m.Error = op.ErrorMsg;
                             return View(view, m);
                         }
-                        SetSuccess(s, successMsg ?? "done");
+                        m.Success = op.SuccessMsg ?? "Completed(No Message Specified)";
 
                         return redirect == null ? RedirectToAction("Index") : redirect();
                     })()
@@ -150,7 +145,8 @@ namespace MVCApplication.Controllers
                     // Gate 3 GET
                     : await new Func<Task<IActionResult>>(async () =>
                     {
-                        var m = Build(table, title);
+                        var op = Store[controllerOp];
+                        var m = Build(op.Table, op.Title);
 
                         if (populate != null)
                         {
@@ -159,7 +155,7 @@ namespace MVCApplication.Controllers
 
                         if (check != null && !check(m))
                         {
-                            m.Error = errorMsg ?? "not found";
+                            m.Error = op.ErrorMsg ?? "ERROR: Operation Failed";
                             return NotFound();
                         }
                         return View(view, m);
@@ -172,29 +168,12 @@ namespace MVCApplication.Controllers
         /// <returns> IActionResult redirect to login if session data doesnt match required params set, otherwise null </returns>
         protected IActionResult? Guard(bool requireAdmin = false, bool requireAuth = false) => (requireAuth || requireAdmin) && !IsAuth ? RedirectToAction("Login", "Account") : requireAdmin && !IsAdmin ? new StatusCodeResult(403) : null;
 
-        /// <summary>
-        /// Method to pass information to view on redirect about status of operation
-        /// </summary>
-        /// <param name="saved"> determines if message is set </param>
-        /// <param name="message"> message to be sent to page </param>
-        protected void SetSuccess(bool saved, string message)
-        {
-            if (saved)
-            {
-                TempData["Success"] = message;
-            }
-            else
-            {
-                TempData["Success"] = null;
-            }
-        }
-
         private async Task SaveLog(bool isError, string view, string message)
         {
             try
             {
-                string userName = HttpContext.Session.GetString("user") ?? "Guest";
-                string role = HttpContext.Session.GetString("role") ?? "Guest";
+                string userName = HttpContext.Session.GetString(SessionKeys.Type) ?? "Guest";
+                string role = HttpContext.Session.GetString(SessionKeys.Role) ?? "Guest";
 
                 await _db.SaveLog(new Log
                 {

--- a/MVCApplication/Controller/DashboardController.cs
+++ b/MVCApplication/Controller/DashboardController.cs
@@ -25,7 +25,7 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <returns>Dashboard view</returns>
         [HttpGet("/Dashboard")]
-        public Task<IActionResult> Index() => GraveMind(Dashboard.Index, Store[MethodCode.DashBoardIndex].Table, Store[MethodCode.DashBoardIndex].Title, auth: true);
+        public Task<IActionResult> Index() => GraveMind(Dashboard.Index, MethodCode.DashBoardIndex, auth: true);
 
         /// <summary>
         /// Handles HTTP GET requests for the My Bookings dashboard view, retrieving and displaying bookings associated
@@ -38,8 +38,7 @@ namespace MVCApplication.Controllers
         [HttpGet("/Dashboard/MyBookings")]
         public Task<IActionResult> MyBookings() => GraveMind(
             Dashboard.MyBookings,
-            Store[MethodCode.DashBoardBooking].Table,
-            Store[MethodCode.DashBoardBooking].Title,
+            MethodCode.DashBoardBooking,
             populate: async m =>
             {
                 var email = User.Identity?.Name;
@@ -53,8 +52,6 @@ namespace MVCApplication.Controllers
                 var (bs, _) = await _db.GetBookingByEmail(email);
                 m.Bookings = bs ?? [];
             },
-            errorMsg: Store[MethodCode.DashBoardBooking].ErrorMsg,
-            successMsg: Store[MethodCode.DashBoardBooking].SuccessMsg,
             auth: true
         );
 
@@ -71,8 +68,7 @@ namespace MVCApplication.Controllers
         [HttpGet("/Dashboard/Profile")]
         public Task<IActionResult> Profile() => GraveMind(
             Dashboard.Profile,
-            Store[MethodCode.DashBoardProfile].Table,
-            Store[MethodCode.DashBoardProfile].Title,
+            MethodCode.DashBoardProfile,
             populate: async m =>
             {
                 var email = User.Identity?.Name;
@@ -86,8 +82,6 @@ namespace MVCApplication.Controllers
                 var (_, user) = await _db.GetUserByEmail(email);
                 m.User = user;
             },
-            errorMsg: Store[MethodCode.DashBoardProfile].ErrorMsg,
-            successMsg: Store[MethodCode.DashBoardProfile].SuccessMsg,
             auth: true
         );
     }

--- a/MVCApplication/Controller/EventsController.cs
+++ b/MVCApplication/Controller/EventsController.cs
@@ -24,15 +24,15 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <returns>Events view with data</returns>
         [HttpGet("/Events")]
-        public Task<IActionResult> Index() => GraveMind(Events.Index, Store[MethodCode.EventsIndex].Table, Store[MethodCode.EventsIndex].Title, 
-            populate: async m => { var (events, _) = await _db.GetEvent(null); m.Events = events ?? [];}, errorMsg: Store[MethodCode.EventsIndex].ErrorMsg, successMsg: Store[MethodCode.EventsIndex].SuccessMsg);
+        public Task<IActionResult> Index() => GraveMind(Events.Index, MethodCode.EventsIndex, 
+            populate: async m => { var (events, _) = await _db.GetEvent(null); m.Events = events ?? [];});
 
         /// <summary>
         /// Displays the event creation page for authenticated users.
         /// </summary>
         /// <returns>Create event view</returns>
         [HttpGet("/Events/Create")]
-        public Task<IActionResult> Create() => GraveMind(Events.Create, Store[MethodCode.EventsCreate].Table, Store[MethodCode.EventsCreate].Title, auth: true);
+        public Task<IActionResult> Create() => GraveMind(Events.Create, MethodCode.EventsCreate, auth: true);
 
         /// <summary>
         /// Handles event creation by validating input and saving the new event to the database.
@@ -41,13 +41,10 @@ namespace MVCApplication.Controllers
         /// <returns>Redirects on success or returns the view with errors</returns>
         [HttpPost("/Events/Create")]
         public Task<IActionResult> Create(Event singleEvent) => !ModelState.IsValid 
-            ? GraveMind(Events.Create, Store[MethodCode.EventsCreateInvalid].Table, Store[MethodCode.EventsCreateInvalid].Title, auth: true, 
-                populate: async m => { m.Event = singleEvent; await Task.CompletedTask;}, 
-                errorMsg: Store[MethodCode.EventsCreateInvalid].ErrorMsg)  
-            : GraveMind(Events.Create, Store[MethodCode.EventsCreate].Table, Store[MethodCode.EventsCreate].Title,
-                auth: true,
-                errorMsg: Store[MethodCode.EventsCreate].ErrorMsg,
-                successMsg: Store[MethodCode.EventsCreate].SuccessMsg, 
+            ? GraveMind(Events.Create, MethodCode.EventsCreateInvalid, auth: true, 
+                populate: async m => { m.Event = singleEvent; await Task.CompletedTask;})  
+            : GraveMind(Events.Create, MethodCode.EventsCreate,
+                auth: true, 
                 save: () =>  _db.SaveEvent(singleEvent), 
                 redirect: () => RedirectToAction("Details"));
 
@@ -56,7 +53,7 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <returns>Event details view</returns>
         [HttpGet("/Events/Details")]
-        public Task<IActionResult> Details() => GraveMind(Events.Details, "events", "Event details");
+        public Task<IActionResult> Details() => GraveMind(Events.Details, MethodCode.EventsDetails);
 
         /// <summary>
         /// Retrieves and displays specific event details based on the provided ID.
@@ -65,13 +62,11 @@ namespace MVCApplication.Controllers
         /// <returns>Event details view with data or error if not found</returns>
         [HttpGet("/Events/{id}")]
         public Task<IActionResult> Details(int id) => 
-            GraveMind(Events.Details, Store[MethodCode.EventsDetails].Table, Store[MethodCode.EventsDetails].Title, 
+            GraveMind(Events.Details, MethodCode.EventsDetails, 
                 populate: async m => { 
                     var (_, _event) = await _db.GetEvent(id); 
                     m.Event = _event; 
                 }, 
-                check: m => m.Event != null,
-                errorMsg: Store[MethodCode.EventsDetails].ErrorMsg,
-                successMsg: Store[MethodCode.EventsDetails].SuccessMsg);
+                check: m => m.Event != null);
     }
 }

--- a/MVCApplication/Controller/HomeController.cs
+++ b/MVCApplication/Controller/HomeController.cs
@@ -40,21 +40,21 @@ namespace MVCApplication.Controllers
         /// <returns>Home view</returns>
         [HttpGet("/")]
         [HttpGet("/Home")]
-        public Task<IActionResult> Index() => GraveMind(Home.Index, Store[MethodCode.HomeIndex].Table, Store[MethodCode.HomeIndex].Title);
+        public Task<IActionResult> Index() => GraveMind(Home.Index, MethodCode.HomeIndex);
 
         /// <summary>
         /// Displays the announcements page.
         /// </summary>
         /// <returns>Announcements view</returns>
         [HttpGet("/Announcements")]
-        public Task<IActionResult> Announcements() => GraveMind(Home.Announcements, Store[MethodCode.HomeAnnouncements].Table, Store[MethodCode.HomeAnnouncements].Title);
+        public Task<IActionResult> Announcements() => GraveMind(Home.Announcements, MethodCode.HomeAnnouncements);
 
         /// <summary>
         /// Displays the feedback form page.
         /// </summary>
         /// <returns>Feedback form view</returns>
         [HttpGet("/Feedback")]
-        public Task<IActionResult> Feedback() => GraveMind(Home.Feedback, Store[MethodCode.HomeFeedBack].Table, Store[MethodCode.HomeFeedBack].Title);
+        public Task<IActionResult> Feedback() => GraveMind(Home.Feedback, MethodCode.HomeFeedBack);
 
         /// <summary>
         /// Handles feedback form submission by validating input and saving the feedback to the database.
@@ -63,13 +63,11 @@ namespace MVCApplication.Controllers
         /// <returns>Redirects on success or returns the view with errors</returns>
         [HttpPost("/Feedback")]
         public Task<IActionResult> Feedback(Feedback feedback) => !ModelState.IsValid
-            ? GraveMind(Home.Feedback, Store[MethodCode.HomeFeedBackInvalid].Table, Store[MethodCode.HomeFeedBackInvalid].Title,
+            ? GraveMind(Home.Feedback, MethodCode.HomeFeedBackInvalid,
                 populate: async m => { m.Error = Store[MethodCode.HomeFeedBackInvalid].ErrorMsg;
                     await Task.CompletedTask; })
-            : GraveMind(Home.Feedback, Store[MethodCode.HomeFeedBack].Table, Store[MethodCode.HomeFeedBack].Title,
+            : GraveMind(Home.Feedback, MethodCode.HomeFeedBack,
                 save: () => _db.SaveFeedback(feedback),
-                errorMsg: Store[MethodCode.HomeFeedBack].ErrorMsg,
-                successMsg: Store[MethodCode.HomeFeedBack].SuccessMsg,
                 redirect: () => RedirectToAction("Index"));
 
 
@@ -78,7 +76,7 @@ namespace MVCApplication.Controllers
         /// </summary>
         /// <returns>FAQ view</returns>
         [HttpGet("/FAQ")]
-        public Task<IActionResult> FAQ() => GraveMind(Home.FAQ, Store[MethodCode.HomeFAQ].Table, Store[MethodCode.HomeFAQ].Title);
+        public Task<IActionResult> FAQ() => GraveMind(Home.FAQ, MethodCode.HomeFAQ);
 
         /// <summary>
         /// Displays the confirmation page.

--- a/MVCApplication/Controller/ServicesController.cs
+++ b/MVCApplication/Controller/ServicesController.cs
@@ -3,7 +3,7 @@ using MVCApplication.Data;
 using MVCApplication.Models;
 using static MVCApplication.Helpers.V;
 using static MVCApplication.Helpers.MessageDictionary;
-using System.Reflection.Metadata.Ecma335;
+using static MVCApplication.Helpers.ActionEnums;
 
 namespace MVCApplication.Controllers
 {
@@ -26,8 +26,8 @@ namespace MVCApplication.Controllers
         /// <param name="id">Optional booking ID</param>
         /// <returns>Services view with booking data</returns>
         [HttpGet("/Services")]
-        public Task<IActionResult> Index(int? id) => GraveMind(Services.Index, Store[MethodCode.ServiceIndex].Table, Store[MethodCode.ServiceIndex].Title,
-            populate: async m => { var (bs, b) = await _db.GetBooking(id); m.Bookings = bs ?? []; m.Booking = b; }, errorMsg: Store[MethodCode.ServiceIndex].ErrorMsg);
+        public Task<IActionResult> Index(int? id) => GraveMind(Services.Index, MethodCode.ServiceIndex,
+            populate: async m => { var (bs, b) = await _db.GetBooking(id); m.Bookings = bs ?? []; m.Booking = b; });
 
         /// <summary>
         /// Handles user actions from the services page such as navigating to details or booking pages.
@@ -36,19 +36,17 @@ namespace MVCApplication.Controllers
         /// <param name="action">Action to perform (Details or Book)</param>
         /// <returns>Redirects based on action or returns the view</returns>
         [HttpPost("/Services")]
-        public Task<IActionResult> Index(int id, string action) =>
-         string.IsNullOrEmpty(action)
+        public Task<IActionResult> Index(int id, ServiceAction? action) => action == null
         ? GraveMind(Services.Index,
-            Store[MethodCode.ServiceIndex].Table,
-            Store[MethodCode.ServiceIndex].Title)
+            MethodCode.ServiceIndex)
         : action switch
         {
-            "Details" => GraveMind(Services.Index,
-                Store[MethodCode.ServiceDetail].Table,Store[MethodCode.ServiceDetail].Title,
+            ServiceAction.Details => GraveMind(Services.Index,
+                MethodCode.ServiceDetail,
                 save: () => Task.FromResult(true),redirect: () => RedirectToAction("Details", new { id })),
 
-            "Book" => GraveMind(Services.Index,
-                Store[MethodCode.ServiceBook].Table,Store[MethodCode.ServiceBook].Title,
+            ServiceAction.Book => GraveMind(Services.Index,
+                MethodCode.ServiceBook,
                 save: () => Task.FromResult(true),redirect: () => RedirectToAction("Book")),
             _ => Task.FromResult<IActionResult>(NotFound())
         };
@@ -59,14 +57,14 @@ namespace MVCApplication.Controllers
         /// <param name="id">Booking ID</param>
         /// <returns>Booking details view or error if not found</returns>
         [HttpGet("/Services/Details/{Id}")]
-        public Task<IActionResult> Details(int id) => GraveMind(Services.Details, Store[MethodCode.ServiceDetail].Table, Store[MethodCode.ServiceDetail].Title, populate: async m => { var (_, b) = await _db.GetBooking(id); m.Booking = b; }, check: m => m.Booking != null, errorMsg: Store[MethodCode.ServiceDetail].ErrorMsg);
+        public Task<IActionResult> Details(int id) => GraveMind(Services.Details, MethodCode.ServiceDetail, populate: async m => { var (_, b) = await _db.GetBooking(id); m.Booking = b; }, check: m => m.Booking != null);
         
         /// <summary>
         /// Displays the booking page for authenticated users.
         /// </summary>
         /// <returns>Booking form view</returns>
         [HttpGet("/Services/Book")]
-        public Task<IActionResult> Book() => GraveMind(Services.Book, Store[MethodCode.ServiceBook].Table, Store[MethodCode.ServiceBook].Title, auth : true);
+        public Task<IActionResult> Book() => GraveMind(Services.Book,MethodCode.ServiceBook, auth : true);
 
         /// <summary>
         /// Handles booking submission by validating input and saving the booking to the database.
@@ -75,11 +73,9 @@ namespace MVCApplication.Controllers
         /// <returns>Redirects on success or returns the view with errors</returns>
         [HttpPost("/Services/Book")]
         public Task<IActionResult> Book(Booking booking) => ModelState.IsValid 
-            ? GraveMind(Services.Book, Store[MethodCode.ServiceBook].Table, Store[MethodCode.ServiceBook].Title, 
-                save: async () => await _db.SaveBooking(booking), errorMsg: Store[MethodCode.ServiceBook].ErrorMsg, 
-                successMsg: Store[MethodCode.ServiceBook].SuccessMsg) 
-            : GraveMind(Services.Book, Store[MethodCode.ServiceBookInvalid].Table, Store[MethodCode.ServiceBookInvalid].Title, 
-                populate: async m => { m.Booking = booking; await Task.CompletedTask;}, 
-                errorMsg: Store[MethodCode.ServiceBookInvalid].ErrorMsg);
+            ? GraveMind(Services.Book, MethodCode.ServiceBook, 
+                save: async () => await _db.SaveBooking(booking)) 
+            : GraveMind(Services.Book, MethodCode.ServiceBookInvalid, 
+                populate: async m => { m.Booking = booking; await Task.CompletedTask;});
     }
 }

--- a/MVCApplication/Data/Seeding.cs
+++ b/MVCApplication/Data/Seeding.cs
@@ -2,20 +2,23 @@
 using System.Data;
 using Dapper;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using MVCApplication.Models.Seeding;
 
 namespace MVCApplication.Data
 {
     public class Seeding
     {
+        private readonly AdminSettings _adminSettings;
         private readonly string _conn;
-        public Seeding(IConfiguration cfg) => _conn = cfg.GetConnectionString("Default") ?? "Data Source=app.db";
+        public Seeding(IConfiguration cfg, IOptions<AdminSettings> adminSettings) => (_conn, _adminSettings) = (cfg.GetConnectionString("Default") ?? "Data Source=app.db", adminSettings.Value);  
         public async Task SeedAdminUser()
         {
             using var s = new SqliteConnection(_conn);
             var exist = await s.ExecuteScalarAsync<int>("select count(1) from users where role = 'admin'");
             if (exist > 0) return;
 
-            var hashedPassword = BCrypt.Net.BCrypt.EnhancedHashPassword("admin123");
+            var hashedPassword = BCrypt.Net.BCrypt.EnhancedHashPassword(_adminSettings.SeedPassword);
             var id = await s.ExecuteScalarAsync<int>(@"insert into users(Email, PasswordHash, Username, FullName, Role) values(@email, @hash, @username, @fullname, 'admin')  returning id",  new { email = "admin@example.com", hash = hashedPassword, username = "admin",fullname = "Admin User" });
         }
     }

--- a/MVCApplication/Helpers/ActionEnums.cs
+++ b/MVCApplication/Helpers/ActionEnums.cs
@@ -1,0 +1,18 @@
+﻿namespace MVCApplication.Helpers
+{
+    public static class ActionEnums
+    {
+        public enum AdminUserAction
+        {
+            Create, 
+            Update, 
+            Delete
+        }
+        public enum ServiceAction
+        {
+            Details,
+            Book
+        }
+
+    }
+}

--- a/MVCApplication/Helpers/SessionMetaData.cs
+++ b/MVCApplication/Helpers/SessionMetaData.cs
@@ -1,0 +1,13 @@
+﻿namespace MVCApplication.Helpers
+{
+    public static class SessionKeys
+    {
+        public const string Type = "user";
+        public const string Role = "role";
+    }
+    public enum UserRole
+    {
+        user,
+        admin
+    }
+}

--- a/MVCApplication/Models/Seeding/AdminSettings.cs
+++ b/MVCApplication/Models/Seeding/AdminSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace MVCApplication.Models.Seeding
+{
+    public class AdminSettings
+    {
+        public string SeedPassword { get; set; } = "";
+    }
+}

--- a/MVCApplication/Program.cs
+++ b/MVCApplication/Program.cs
@@ -1,5 +1,6 @@
 using MVCApplication.Data;
 using MVCApplication.XMLServices;
+using MVCApplication.Models.Seeding;
 
 namespace MVCApplication
 {
@@ -14,6 +15,8 @@ namespace MVCApplication
 
             //Register XML configuration service (loads Config/*.xml)
             builder.Services.AddSingleton<IXMLConfigService, XMLConfigService>();
+            builder.Services.Configure<AdminSettings>(builder.Configuration.GetSection("AdminSettings"));
+
 
             // Add services to the container.
             builder.Services.AddControllersWithViews();

--- a/MVCApplication/appsettings.Development.json
+++ b/MVCApplication/appsettings.Development.json
@@ -1,8 +1,15 @@
+
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    
+    "AdminSettings": {
+        "SeedPassword": "admin123"
     }
-  }
+    
 }
+


### PR DESCRIPTION
- Enum for switch cases for type safety
- Enum for User Role assignment for readability
- Const Strings for SessionMetaData of users being logged in or admin
- Fixed admin logging in issues -Admin password was "test" in register and "admin123" in seeding -Removed both string literals, password located on appsettingdevlopment.json as a single source of truth for both operations
- Cleaned up some code